### PR TITLE
Update blocklist.yaml

### DIFF
--- a/lists/blocklist.yaml
+++ b/lists/blocklist.yaml
@@ -53,7 +53,6 @@
   - url: collab-award.io
   - url: claimray.net
   - url: jup.pro
-  - url: moonroll.io
   - url: dropbonk.space
   - url: guac-drop.netlify.app
   - url: jupjup2.com


### PR DESCRIPTION
Removing moonroll.io from blocklist as they are a legit website