### PR TITLE
Update blocklist.yaml

### DIFF
--- a/lists/blocklist.yaml
+++ b/lists/blocklist.yaml
@@ -114,3 +114,5 @@
   - url: solflare.ai
   - url: solflare.world
   - url: solflare.lu
+  - url: claim-jupswap.com
+  - url: gift-jupswap.com


### PR DESCRIPTION
Subject: Phishing Site Impersonating Solana Project – Immediate Action Requested

Domain(s):

https://claim-jupswap.com (redirects to https://gift-jupswap.com)

https://gift-jupswap.com

Description:

The websites listed above are part of an active phishing campaign targeting Solana users. The initial domain (claim-jupswap.com) redirects to gift-jupswap.com, which impersonates a legitimate Solana-related service and attempts to deceive users into entering their 12/24-word seed phrases under the pretense of claiming an airdrop or voucher.